### PR TITLE
Define SHELL as Bash, script blocks use Bashisms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # latest Linux releases can be found here:
 # http://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/#post-2429209
+SHELL := /bin/bash
 TAG := 5.3.3f1+20160223
 PKG := unity-editor-$(TAG)_amd64.deb
 URL := http://download.unity3d.com/download_unity/linux/$(PKG)


### PR DESCRIPTION
Without this the script fails on Debian/Ubuntu distributions because their /bin/sh (Make's default shell) is actually Dash, which doesn't support Bashisms.
